### PR TITLE
Fix the Narrow Title TextField on EditorPage

### DIFF
--- a/editor/src/main/java/com/github/kitakkun/noteapp/editor/editor/composable/EditorTopBar.kt
+++ b/editor/src/main/java/com/github/kitakkun/noteapp/editor/editor/composable/EditorTopBar.kt
@@ -1,5 +1,6 @@
 package com.github.kitakkun.noteapp.editor.editor.composable
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.NavigateBefore
@@ -12,6 +13,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.github.kitakkun.noteapp.customview.preview.PreviewContainer
 
@@ -34,6 +36,7 @@ fun EditorTopBar(
                 value = title,
                 onValueChange = onTitleChange,
                 textStyle = MaterialTheme.typography.titleLarge.copy(color = MaterialTheme.colorScheme.onSurface),
+                modifier = Modifier.fillMaxWidth()
             )
         },
         navigationIcon = {


### PR DESCRIPTION
The TextField for Title input was too narrow to interact with.
This may lead uncomfortable user experience. Fixed it.